### PR TITLE
Remove timestamp to allow reproducible builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,12 @@ android {
     }
 }
 
+// Make app reproducible by removing timestamp.
+// https://github.com/mikepenz/AboutLibraries/issues/784#issuecomment-1205501876
+aboutLibraries {
+    excludeFields = [ "generated" ]
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.core:core-ktx:1.12.0"


### PR DESCRIPTION
This removes the metadata.generated timestamp in a json file generated by AboutLibraries. This value is not really needed, but breaks reproducible builds, as different timestamps are saved. https://github.com/mikepenz/AboutLibraries/issues/784#issuecomment-1205501876

Without this timestamp the app is fully reproducible.

With the next release F-Droid can leverage the reproducible build.