### PR TITLE
Fix foreground service start from quick tile

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,11 @@ android {
     androidResources {
         generateLocaleConfig true
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 // Make app reproducible by removing timestamp.
@@ -63,4 +68,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
     implementation "com.mikepenz:aboutlibraries:$about_libraries_version"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.robolectric:robolectric:4.16.1"
 }

--- a/app/src/main/java/com/github/muellerma/coffee/activities/CoffeeInvisibleActivity.kt
+++ b/app/src/main/java/com/github/muellerma/coffee/activities/CoffeeInvisibleActivity.kt
@@ -1,6 +1,8 @@
 package com.github.muellerma.coffee.activities
 
 import android.app.Activity
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import com.github.muellerma.coffee.ForegroundService
@@ -20,5 +22,10 @@ class CoffeeInvisibleActivity : Activity() {
     companion object {
         private val TAG = CoffeeInvisibleActivity::class.java.simpleName
         const val ACTION_TOGGLE = "toggle"
+
+        fun toggleIntent(context: Context): Intent =
+            Intent(context, CoffeeInvisibleActivity::class.java)
+                .setAction(ACTION_TOGGLE)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
 }

--- a/app/src/main/java/com/github/muellerma/coffee/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/muellerma/coffee/activities/MainActivity.kt
@@ -146,8 +146,7 @@ class MainActivity : AppCompatActivity(), ServiceStatusObserver {
     private fun getShortcutInfo(stableId: Boolean): ShortcutInfoCompat {
         Log.d(TAG, "getShortcutInfo($stableId)")
         val id = if (stableId) "toggle" else "toggle-${System.currentTimeMillis()}"
-        val intent = Intent(this, CoffeeInvisibleActivity::class.java)
-            .setAction(CoffeeInvisibleActivity.ACTION_TOGGLE)
+        val intent = CoffeeInvisibleActivity.toggleIntent(this)
         return ShortcutInfoCompat.Builder(this, id)
             .setIntent(intent)
             .setShortLabel(getString(R.string.app_name))

--- a/app/src/main/java/com/github/muellerma/coffee/tiles/AbstractTile.kt
+++ b/app/src/main/java/com/github/muellerma/coffee/tiles/AbstractTile.kt
@@ -1,5 +1,7 @@
 package com.github.muellerma.coffee.tiles
 
+import android.annotation.SuppressLint
+import android.app.PendingIntent
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -9,6 +11,7 @@ import android.util.Log
 import androidx.annotation.CallSuper
 import androidx.annotation.RequiresApi
 import com.github.muellerma.coffee.R
+import com.github.muellerma.coffee.activities.CoffeeInvisibleActivity
 import com.github.muellerma.coffee.ServiceStatus
 import com.github.muellerma.coffee.coffeeApp
 import com.github.muellerma.coffee.toFormattedTime
@@ -65,6 +68,23 @@ abstract class AbstractTile : TileService() {
                 subtitle = tileSubtitle
             }
             updateTile()
+        }
+    }
+
+    @SuppressLint("StartActivityAndCollapseDeprecated")
+    @Suppress("DEPRECATION")
+    protected fun launchToggleActivity() {
+        val intent = CoffeeInvisibleActivity.toggleIntent(this)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val pendingIntent = PendingIntent.getActivity(
+                this,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE
+            )
+            startActivityAndCollapse(pendingIntent)
+        } else {
+            startActivityAndCollapse(intent)
         }
     }
 

--- a/app/src/main/java/com/github/muellerma/coffee/tiles/TimeoutTile.kt
+++ b/app/src/main/java/com/github/muellerma/coffee/tiles/TimeoutTile.kt
@@ -19,7 +19,7 @@ class TimeoutTile : AbstractTile() {
         when {
             coffeeApp().lastStatusUpdate is ServiceStatus.Stopped -> {
                 prefs.timeout = prefs.firstTimeout
-                ForegroundService.changeState(this, ForegroundService.Companion.STATE.START, false)
+                launchToggleActivity()
             }
             prefs.nextTimeout == 0 -> {
                 prefs.timeout = 0

--- a/app/src/main/java/com/github/muellerma/coffee/tiles/ToggleTile.kt
+++ b/app/src/main/java/com/github/muellerma/coffee/tiles/ToggleTile.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
-import com.github.muellerma.coffee.ForegroundService
 import com.github.muellerma.coffee.ServiceStatus
 import com.github.muellerma.coffee.ServiceStatusObserver
 
@@ -13,7 +12,7 @@ import com.github.muellerma.coffee.ServiceStatusObserver
 class ToggleTile : AbstractTile() {
     override fun onClick() {
         Log.d(TAG, "onClick()")
-        ForegroundService.changeState(this, ForegroundService.Companion.STATE.TOGGLE, false)
+        launchToggleActivity()
         super.onClick()
     }
 

--- a/app/src/test/java/com/github/muellerma/coffee/activities/CoffeeInvisibleActivityTest.kt
+++ b/app/src/test/java/com/github/muellerma/coffee/activities/CoffeeInvisibleActivityTest.kt
@@ -1,0 +1,23 @@
+package com.github.muellerma.coffee.activities
+
+import android.content.Context
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class CoffeeInvisibleActivityTest {
+    private val context: Context = RuntimeEnvironment.getApplication()
+
+    @Test
+    fun toggleIntent_targetsCoffeeInvisibleActivity() {
+        val intent = CoffeeInvisibleActivity.toggleIntent(context)
+
+        assertEquals(CoffeeInvisibleActivity::class.java.name, intent.component?.className)
+        assertEquals(CoffeeInvisibleActivity.ACTION_TOGGLE, intent.action)
+        assertEquals(Intent.FLAG_ACTIVITY_NEW_TASK, intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+}


### PR DESCRIPTION
Hi
First, thanks for Coffee. I use it regularly.

# Description
Quick Settings tiles can no longer start the foreground service directly on recent Android versions.

## Changes
- tile activation is now routed through `CoffeeInvisibleActivity`
- `PendingIntent` is used on Android 14+
- I added a little test